### PR TITLE
Update AdminTour.php and pointer-dashboard.php

### DIFF
--- a/src/Admin/AdminTour.php
+++ b/src/Admin/AdminTour.php
@@ -147,7 +147,7 @@ class AdminTour {
 						$pointers = array(
 							array(
 								// @link https://github.com/WordPress/WordPress/blob/4.7/wp-admin/edit.php#L321
-								'selector' => '.wrap .wp-header-end',
+								'selector' => '#dashboard-widgets-wrap',
 								'options'  => (object) array(
 									'content'      => $this->get_content( 'pointer-dashboard' ),
 									'position'     => (object) array(

--- a/views/pointer-dashboard.php
+++ b/views/pointer-dashboard.php
@@ -13,7 +13,7 @@
 
 <p>
 	<?php esc_html_e( 'On the Pronamic Pay dashboard you can restart this tour and see an overview of the latest pending payments.', 'pronamic_ideal' ); ?>
-	<?php esc_html_e( 'It also gives you access to the “Getting Started” and “System Status” pages in case you have issues.', 'pronamic_ideal' ); ?>
+	<?php esc_html_e( 'It also gives you access to the “Getting Started” and “Site Health” pages in case you have issues.', 'pronamic_ideal' ); ?>
 	<?php esc_html_e( 'And you can follow the latest news from the Pronamic.eu weblog.', 'pronamic_ideal' ); ?>
 </p>
 


### PR DESCRIPTION
Class wp-header-end is not present in wordpress 5.4.1, because of which tutorial was not getting displayed on dashboard. That's why changing position of tutorial popup box.