### PR TITLE
get_config_select_options bugfix for unknown payment method

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -688,6 +688,10 @@ class Plugin {
 			$args['post__in'] = PaymentMethods::get_config_ids( $payment_method );
 		}
 
+		if ( null !== $payment_method && empty( $args['post__in'] ) ) {
+		    $args['post__in'] = array(0);
+		}
+
 		$query = new WP_Query( $args );
 
 		$options = array( __( '— Select Configuration —', 'pronamic_ideal' ) );


### PR DESCRIPTION
get_config_select_options was returning all configurations if configurations with provided payment_method not found. Bug Fixed

Update Plugin.php