### PR TITLE
Added missing On Hold status in status map.

### DIFF
--- a/src/Payments/PaymentsDataStoreCPT.php
+++ b/src/Payments/PaymentsDataStoreCPT.php
@@ -67,6 +67,7 @@ class PaymentsDataStoreCPT extends LegacyPaymentsDataStoreCPT {
 			PaymentStatus::RESERVED  => 'payment_reserved',
 			PaymentStatus::SUCCESS   => 'payment_completed',
 			PaymentStatus::OPEN      => 'payment_pending',
+			PaymentStatus::ON_HOLD   => 'payment_on_hold',
 		);
 	}
 


### PR DESCRIPTION
Added missing "On Hold" status in status map. Because of this missing status, "On Hold" status was not getting updated if the WordPress admin was trying to manually mark this payment on hold from the "Edit Payment" page. The below code was stopping the admin to mark the payment on "On Hold" status.

https://github.com/wp-pay/core/blob/45935633045736d3cae6c548270a815e27f747cd/src/Payments/PaymentsDataStoreCPT.php#L209-L213